### PR TITLE
Suite host select fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ language: python
 
 matrix:
     include:
-    - name: "1"
+    - name: "1/4"
       env: CHUNK='1/4'
-    - name: "2"
+    - name: "2/4"
       env: CHUNK='2/4'
-    - name: "3"
+    - name: "3/4"
       env: CHUNK='3/4'
-    - name: "4"
+    - name: "4/4"
       env: CHUNK='4/4'
 
 
@@ -78,7 +78,7 @@ script:
     # Only run the generic tests on Travis CI.
     - export CYLC_TEST_RUN_PLATFORM=false
     # Run tests with virtual frame buffer for X support.
-    - xvfb-run -a cylc test-battery --chunk $CHUNK --state=save -j 5 || (echo -e "\n\nRerunning Failed Tests...\n\n"; cylc test-battery --state=save,failed -j 5)
+    - xvfb-run -a cylc test-battery --chunk $CHUNK --state=save -j 5 || (echo -e "\n\nRerunning Failed Tests...\n\n"; cylc test-battery --state=failed -j 5)
 
 # Check output (more useful if you narrow down what tests get run)
 after_script:

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -418,10 +418,10 @@ def main():
                 cmd.append('--remote-arg=%s' % quote(batchview_cmd))
             cmd.append(suite_name)
             capture = (mode == 'edit')
-            manage = (mode == 'tail')
             try:
-                proc = remote_cylc_cmd(cmd, user, host, capture=capture,
-                                       manage=manage)
+                proc = remote_cylc_cmd(
+                    cmd, user, host, capture_process=capture,
+                    manage=(mode == 'tail'))
             except KeyboardInterrupt:
                 # Ctrl-C while tailing.
                 pass

--- a/bin/cylc-gpanel
+++ b/bin/cylc-gpanel
@@ -29,7 +29,7 @@ This applet can be tested using the --test option.
 To customize themes, copy $CYLC_DIR/etc/gcylc.rc.eg to $HOME/.cylc/gcylc.rc and
 follow the instructions in the file.
 
-To configure default suite hosts, edit "[suite host scanning]hosts" in your
+To configure default suite hosts, edit "[suite servers]scan hosts" in your
 global.rc file."""
 
 from optparse import OptionParser

--- a/bin/cylc-gscan
+++ b/bin/cylc-gscan
@@ -82,7 +82,8 @@ def main():
     from cylc.gui.gscan import ScanApp
 
     if options.all_ports:
-        args.extend(glbl_cfg().get(["suite host scanning", "hosts"]))
+        args.extend(glbl_cfg().get(
+            ["suite servers", "scan hosts"], ["localhost"]))
     scan_app = ScanApp(
         hosts=args,
         patterns_name=options.patterns_name,

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -266,4 +266,7 @@ The USER_AT_HOST argument allows suite selection by 'cylc scan' output:
 
 
 if __name__ == "__main__":
-    SuiteMonitor().run()
+    try:
+        SuiteMonitor().run()
+    except KeyboardInterrupt:
+        pass

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -28,8 +28,8 @@ users.
 If a list of HOSTS is specified, it will obtain a listing of running suites by
 scanning all ports in the relevant range for running suites on the specified
 hosts. If the -a/--all option is specified, it will use the global
-configuration "[suite host scanning]" setting to determine a list of hosts to
-scan.
+configuration "[suite servers]scan hosts" setting to determine a list of hosts
+to scan.
 
 Suite passphrases are not needed to get identity information (name and owner).
 Titles, descriptions, state totals, and cycle point state totals may also be
@@ -209,7 +209,8 @@ def main():
     except ValueError as exc:
         parser.error(str(exc))
     if options.all_ports:
-        args.extend(glbl_cfg().get(["suite host scanning", "hosts"]))
+        args.extend(
+            glbl_cfg().get(["suite servers", "scan hosts"], ["localhost"]))
     if not args:
         args = get_scan_items_from_fs(cre_owner)
     if not args:

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -91,10 +91,26 @@ Run only tests under "tests/cyclers/", and skip 00-daily.t
   cylc test-battery tests/cyclers
 Run the first quarter of the test battery
   cylc test-battery --chunk '1/4'
+Re-run failed tests
+  cylc test-battery --state=save
+  cylc test-battery --state=failed
 eof
 }
 
-TESTS=""
+chunk () {
+    # argument in the format chunk_no/no_chunks
+    IFS=$'/' read CHUNK_NO CHUNKS <<< "$1"
+    # create lists of tests in a temp file
+    TEST_FILE="$(mktemp)"
+    cylc test-battery --dry | sort > "$TEST_FILE"
+    LINES_PER_FILE=$(( ( $(wc -l "$TEST_FILE" | cut -d ' ' -f 1) \
+        + $CHUNKS - 1 ) / CHUNKS ))
+    # chunk tests
+    split -d -l "$LINES_PER_FILE" "$TEST_FILE" "$TEST_FILE"
+    # select chunk
+    FILENO="$(printf '%02d' $(( CHUNK_NO - 1 )) )"
+    tr '\n' ' ' < "${TEST_FILE}${FILENO}"
+}
 
 # Defaults.
 export CYLC_TEST_RUN_GENERIC=${CYLC_TEST_RUN_GENERIC:-true}
@@ -108,47 +124,21 @@ if [[ "$PWD" != "$CYLC_DIR" ]]; then
     cd "$CYLC_DIR"
 fi
 
-ARGS=()
-OPTS=()
-while [[ $# -gt 0 ]]; do
-    case "$1" in
+ARG_COUNT=1
+for ARG in "$@"; do
+    case "$ARG" in
         --help|-h)
             usage
             exit 0
             ;;
         --chunk)
-            # argument in the format chunk_no/no_chunks
-            IFS=$'/' read CHUNK_NO CHUNKS <<< "$2"
-            # create lists of tests in a tempdir
-            TMPDIR="$(mktemp -d)"
-            TEST_FILE="$TMPDIR/cylc_tests"
-            prove -r 'tests' --dry > "$TEST_FILE"
-            LINES_PER_FILE=$(( ( $(wc -l "$TEST_FILE" | cut -d ' ' -f 1) \
-                + $CHUNKS - 1 ) / $CHUNKS ))
-            # chunk tests
-            split -d -l "$LINES_PER_FILE" "$TEST_FILE" "$TEST_FILE"
-            # select chunk
-            FILENO="$(printf '%02d' $(( $CHUNK_NO - 1 )) )"
-            ARGS+=($(cat "${TEST_FILE}${FILENO}"))
-            shift
-            shift
-            ;;
-        --exec|--harness|--formatter|--source|--archive|--jobs|\
-        -I|-P|-M|-e|-a|-j)
-            # prove options which take separate arguments
-            OPTS+=("$1" "$2")
-            shift
-            shift
-            ;;
-        -*)
-            # prove single item options
-            OPTS+=("$1")
-            shift
+            # Replace "--chunk a/b" with the appropriate tests.
+            set -- "${@:1:$(( ARG_COUNT - 1 ))}" \
+                $(chunk ${@:$(( ARG_COUNT + 1 )):1}) \
+                "${@:$(( ARG_COUNT + 2 ))}"
             ;;
         *)
-            # prove arguments
-            ARGS+=("$1")
-            shift
+            ARG_COUNT=$(( ARG_COUNT + 1 ))
             ;;
     esac
 done
@@ -164,8 +154,8 @@ if perl -e 'use Test::Harness 3.00' 2>/dev/null; then
     if [[ -z "${NPROC}" ]]; then
         NPROC=$(python -c 'import multiprocessing as mp; print mp.cpu_count()')
     fi
-    exec prove -j "$NPROC" -s -r ${ARGS[@]:-tests} ${OPTS[@]:-}
+    exec prove -j "$NPROC" -s -r "${@:-tests}"
 else
-    echo 'WARNING: cannot run tests in parallel (Test::Harness < 3.00)' >&2
-    exec prove -s -r ${ARGS[@]:-tests} ${OPTS[@]:-}
+    echo "WARNING: cannot run tests in parallel (Test::Harness < 3.00)" >&2
+    exec prove -s -r "${@:-tests}"
 fi

--- a/doc/src/cylc-user-guide/siterc.tex
+++ b/doc/src/cylc-user-guide/siterc.tex
@@ -943,21 +943,6 @@ if you have to use the {\em hardwired} self-identification method.
 \item {\em default:} (none)
 \end{myitemize}
 
-\subsection{[suite host scanning]}
-
-Utilities such as \lstinline=cylc gscan= need to scan hosts for
-running suites. Note this item is deprecated as detailed below.
-
-\subsubsection[hosts]{[suite host scanning] \textrightarrow hosts }
-
-A list of hosts to scan for running suites. This is deprecated in favour of
-scan hosts under suite servers.
-
-\begin{myitemize}
-\item {\em type:} comma-separated list of host names or IP addresses.
-\item {\em default:} localhost
-\end{myitemize}
-
 \subsection{[task events]}
 
 Global site/user defaults for~\ref{TaskEventHandling}.

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -260,10 +260,6 @@ SPEC = {
         'host': vdr(vtype='string'),
     },
 
-    'suite host scanning': {
-        'hosts': vdr(vtype='string_list', default=["localhost"])
-    },
-
     'authentication': {
         # Allow owners to grant public shutdown rights at the most, not full
         # control.
@@ -275,9 +271,9 @@ SPEC = {
     },
 
     'suite servers': {
-        'run hosts': vdr(vtype='string_list', default=["localhost"]),
+        'run hosts': vdr(vtype='string_list'),
         'run ports': vdr(vtype='range_list', default=range(43001, 43101)),
-        'scan hosts': vdr(vtype='string_list', default=["localhost"]),
+        'scan hosts': vdr(vtype='string_list'),
         'scan ports': vdr(vtype='range_list', default=range(43001, 43101)),
         'run host select': {
             'rank': vdr(
@@ -285,7 +281,7 @@ SPEC = {
                 options=["random", "load:1", "load:5", "load:15", "memory",
                          "disk-space"],
                 default="random"),
-            'thresholds': vdr(vtype='string', default=None),
+            'thresholds': vdr(vtype='string'),
         },
     },
 }

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -438,7 +438,7 @@ class TreeUpdater(threading.Thread):
                     f_iter = p_iter
                     f_path = p_path
                     fam = point_string
-                    for i, fam in enumerate(named_path[:-1]):
+                    for j, fam in enumerate(named_path[:-1]):
                         # Construct family nesting for this task.
                         if fam in family_iters:
                             # Family already in tree
@@ -450,8 +450,8 @@ class TreeUpdater(threading.Thread):
                                 f_data = new_fam_data[point_string][fam]
                             except KeyError:
                                 f_data = [None] * 7
-                            if i > 0:
-                                parent_fam = named_path[i - 1]
+                            if j > 0:
+                                parent_fam = named_path[j - 1]
                             else:
                                 # point_string is the implicit parent here.
                                 parent_fam = point_string

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -576,7 +576,7 @@ class SuiteRuntimeServiceClient(object):
             # * Add `-n` to the SSH command
             stdin = None
         proc = remote_cylc_cmd(
-            command, self.owner, self.host, capture=True,
+            command, self.owner, self.host, capture_process=True,
             ssh_login_shell=(self.comms1.get(
                 self.srv_files_mgr.KEY_SSH_USE_LOGIN_SHELL
             ) in ['True', 'true']),

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -18,18 +18,18 @@
 """Common logic for "cylc run" and "cylc restart" CLI."""
 
 import json
-from multiprocessing import Pool
 import os
+from pipes import quote
 from random import shuffle, choice
-import socket
-from subprocess import Popen, PIPE
 import sys
+from time import sleep
 import unittest
 
 from cylc.cfgspec.glbl_cfg import glbl_cfg
-from cylc.hostuserutil import is_remote_host, get_fqdn_by_host
+import cylc.flags
+from cylc.hostuserutil import get_host, is_remote_host
 from cylc.option_parsers import CylcOptionParser as COP
-from cylc.remote import RemoteRunner, construct_ssh_cmd
+from cylc.remote import remrun, remote_cylc_cmd, run_cmd
 from cylc.scheduler import Scheduler
 from cylc.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
@@ -82,20 +82,18 @@ def main(is_restart=False):
 
     # Check whether a run host is explicitly specified, else select one.
     if not options.host:
-        host = HostAppointer(
-            is_debug=options.debug, is_verbose=options.verbose).appoint_host()
-        if is_remote_host(host):
-            if is_restart:
-                base_cmd = ["restart"] + sys.argv[1:]
-            else:
-                base_cmd = ["run"] + sys.argv[1:]
-            # State as relative localhost to prevent recursive host selection.
-            base_cmd.append("--host=localhost")
-            proc = Popen(
-                construct_ssh_cmd(base_cmd, host=host), stdin=open(os.devnull))
-            res = proc.wait()
-            sys.exit(res)
-    if RemoteRunner(set_rel_local=True).execute():  # State localhost as above.
+        host_appointer = HostAppointer()
+        if host_appointer.hosts and host_appointer.hosts != ['localhost']:
+            host = host_appointer.appoint_host()
+            if is_remote_host(host):
+                if is_restart:
+                    base_cmd = ["restart"] + sys.argv[1:]
+                else:
+                    base_cmd = ["run"] + sys.argv[1:]
+                # Prevent recursive host selection
+                base_cmd.append("--host=localhost")
+                return remote_cylc_cmd(base_cmd, host=host)
+    if remrun(set_rel_local=True):  # State localhost as above.
         sys.exit()
 
     scheduler = Scheduler(is_restart, options, args)
@@ -215,7 +213,7 @@ def parse_commandline(is_restart):
     return options, args
 
 
-class EmptyHostList(Exception):
+class EmptyHostList(RuntimeError):
     """Exception to be raised if there are no valid run hosts.
 
     Raise if, from the global configuration settings, no hosts are listed
@@ -247,11 +245,10 @@ class HostAppointer(object):
 
     CMD_BASE = "get-host-metrics"  # 'cylc' prepended by remote_cylc_cmd.
 
-    def __init__(self, is_debug, is_verbose):
+    def __init__(self):
         self.use_disk_path = "/"
         self.max_processes = 5
-        self.is_debug = is_debug
-        self.is_verbose = is_verbose
+        self.is_debug = cylc.flags.debug or cylc.flags.verbose
 
         self.hosts = glbl_cfg().get(['suite servers', 'run hosts'])
         self.rank_method = glbl_cfg().get(
@@ -287,7 +284,7 @@ class HostAppointer(object):
         for one return that item, else (for multiple items) return False.
         """
         if len(host_list) == 0:
-            if self.is_debug or self.is_verbose:
+            if self.is_debug:
                 raise EmptyHostList()
             else:
                 sys.exit(str(EmptyHostList()))
@@ -312,8 +309,8 @@ class HostAppointer(object):
         else:
             return False
 
-    def _process_get_host_metrics_cmd(self):
-        """Return 'get_host_metrics' command to run with only required options.
+    def _get_host_metrics_opts(self):
+        """Return 'get-host-metrics' command to run with only required options.
 
         Return the command string to run 'cylc get host metric' with only
         the required options given rank method and thresholds specified.
@@ -328,11 +325,48 @@ class HostAppointer(object):
                 opts.add("--disk-space=" + self.use_disk_path)
             elif spec == "memory":
                 opts.add("--memory")
+        return opts
 
-        cmd = [self.CMD_BASE] + list(opts)
-        return " ".join(cmd)
+    def _get_host_metrics(self):
+        """Run "cylc get-host-metrics" commands on hosts.
 
-    def _remove_bad_hosts(self, cmd_with_opts, mock_stats=False):
+        Return (dict): {host: host-metrics-dict, ...}
+        """
+        host_stats = {}
+        # Run "cylc get-host-metrics" commands on hosts
+        host_proc_map = {}
+        cmd = [self.CMD_BASE] + sorted(self._get_host_metrics_opts())
+        # Start up commands on hosts
+        for host in self.hosts:
+            if is_remote_host(host):
+                host_proc_map[host] = remote_cylc_cmd(
+                    cmd, stdin=None, host=host, capture_process=True)
+            elif 'localhost' in host_proc_map:
+                continue  # Don't duplicate localhost
+            else:
+                # 1st instance of localhost
+                host_proc_map['localhost'] = run_cmd(
+                    ['cylc'] + cmd, capture_process=True)
+        # Collect results from commands
+        while host_proc_map:
+            for host, proc in host_proc_map.copy().items():
+                if proc.poll() is None:
+                    continue
+                del host_proc_map[host]
+                out, err = proc.communicate()
+                if not proc.wait():  # Command OK
+                    host_stats[host] = json.loads(out)
+                elif cylc.flags.verbose or cylc.flags.debug:
+                    # Command failed in verbose/debug mode
+                    sys.stderr.write((
+                        "WARNING: can't get host metric from '%s';"
+                        " %s  # returncode=%s, err=%s\n" %
+                        (host, ' '.join((quote(item) for item in cmd)),
+                         proc.returncode, err)))
+            sleep(0.01)
+        return host_stats
+
+    def _remove_bad_hosts(self, mock_stats=False):
         """Return dictionary of 'good' hosts with their metric stats.
 
         Run 'get-host-metrics' on each run host in parallel & store extracted
@@ -340,24 +374,13 @@ class HostAppointer(object):
         whereby either metric data cannot be accessed from the command or at
         least one metric value does not pass a specified threshold.
         """
-        cmd = cmd_with_opts.split()
         if mock_stats:  # Create fake data for unittest purposes (only).
             host_stats = dict(mock_stats)  # Prevent mutable object issues.
         else:
             if not self.hosts:
                 return {}
-            proc_pool = Pool(min(len(self.hosts), self.max_processes))
-            be_verbose = self.is_debug or self.is_verbose
-            host_stats = dict(zip(
-                self.hosts,
-                proc_pool.map(get_host_metrics,
-                              zip(self.hosts, [cmd] * len(self.hosts),
-                                  [be_verbose] * len(self.hosts)))
-            ))
-        # Regulate localhost aliases; always process as 'localhost' string key.
-        if get_fqdn_by_host(None) in host_stats:
-            host_stats['localhost'] = host_stats.pop(get_fqdn_by_host(None))
-
+            host_stats = self._get_host_metrics()
+        # Analyse get-host-metrics results
         for host, data in dict(host_stats).items():
             if not data:
                 # No results for host (command failed) -> skip.
@@ -371,7 +394,7 @@ class HostAppointer(object):
                         measure == "memory" or
                         measure.startswith("disk-space")))):
                     # Alert user that threshold has not been met.
-                    if self.is_debug or self.is_verbose:
+                    if self.is_debug:
                         sys.stderr.write((
                             "WARNING: host '%s' did not pass %s threshold "
                             "(%s %s threshold %s)\n" % (
@@ -393,7 +416,7 @@ class HostAppointer(object):
         # metric data values corresponding to the rank method to rank with.
         hosts_with_vals_to_rank = dict((host, metric[self.rank_method]) for
                                        host, metric in all_host_stats.items())
-        if self.is_debug or self.is_verbose:
+        if self.is_debug:
             print "INFO: host %s values extracted are:" % self.rank_method
             for host, value in hosts_with_vals_to_rank.items():
                 print "  " + host + ": " + str(value)
@@ -405,17 +428,17 @@ class HostAppointer(object):
                     "following order, from most to least suitable: ")
         if self.rank_method in ("memory", "disk-space:" + self.use_disk_path):
             # Want 'most free' i.e. highest => reverse asc. list for ranking.
-            if self.is_debug or self.is_verbose:
+            if self.is_debug:
                 sys.stderr.write(
                     base_msg + ', '.join(sort_asc_hosts[::-1]) + '.\n')
             return sort_asc_hosts[-1]
         else:  # A load av. is only poss. left; 'random' dealt with earlier.
             # Want lowest => ranking given by asc. list.
-            if self.is_debug or self.is_verbose:
+            if self.is_debug:
                 sys.stderr.write(base_msg + ', '.join(sort_asc_hosts) + '.\n')
             return sort_asc_hosts[0]
 
-    def appoint_host(self, override_stats=False):
+    def appoint_host(self, mock_stats=False):
         """Appoint the most suitable host to (re-)run a suite on."""
         # Check if immediately 'trivial': no thresholds and zero or one hosts.
         initial_check = self._trivial_choice(
@@ -423,8 +446,7 @@ class HostAppointer(object):
         if initial_check:
             return initial_check
 
-        good_host_stats = self._remove_bad_hosts(
-            self._process_get_host_metrics_cmd(), mock_stats=override_stats)
+        good_host_stats = self._remove_bad_hosts(mock_stats=mock_stats)
 
         # Re-check for triviality after bad host removal; otherwise must rank.
         pre_rank_check = self._trivial_choice(good_host_stats.keys())
@@ -434,40 +456,12 @@ class HostAppointer(object):
         return self._rank_good_hosts(good_host_stats)
 
 
-def get_host_metrics((host, cmd, be_verbose)):
-    """Wrapper for the `cylc get-host-metric` command.
-
-    NOTE: multiprocessing.Pool.map does not work.
-    """
-    try:
-        if (host == 'localhost' or
-                get_fqdn_by_host(host) == get_fqdn_by_host(None)):
-            host = None
-    except socket.gaierror:
-        if be_verbose:
-            # No such host.
-            sys.stderr.write("WARNING: no such host '%s'; excluding as "
-                             "possible run host & continuing.\n" % host)
-        return
-
-    process = Popen(construct_ssh_cmd(
-        cmd, host=host), stdin=open(os.devnull), stdout=PIPE, stderr=PIPE)
-    if process.wait():
-        if be_verbose:
-            # Command failed.
-            sys.stderr.write((
-                "WARNING: can't obtain metric data from host '%s'; return "
-                "code '%s' from '%s'\n" % (host, process.returncode, cmd)))
-        return
-    return json.loads(process.communicate()[0])
-
-
 class TestHostAppointer(unittest.TestCase):
     """Unit tests for the HostAppointer class."""
 
     def setUp(self):
         """Create HostAppointer class instance to test."""
-        self.app = HostAppointer(is_debug=False, is_verbose=False)
+        self.app = HostAppointer()
 
     def create_custom_metric(self, disk_int, mem_int, load_floats):
         """Non-test method to create and return a dummy metric for testing.
@@ -625,30 +619,22 @@ class TestHostAppointer(unittest.TestCase):
             False
         )
 
-    def test_process_get_host_metric_cmd(self):
-        """Test the '_process_get_host_metrics_cmd' method."""
+    def test_get_host_metrics_opts(self):
+        """Test the '_get_host_metrics_opts' method."""
         self.mock_global_config()
-        self.assertEqual(
-            self.app._process_get_host_metrics_cmd(),
-            'get-host-metrics'
-        )
+        self.assertEqual(self.app._get_host_metrics_opts(), set())
         self.mock_global_config(set_thresholds='memory 1000')
         self.assertEqual(
-            self.app._process_get_host_metrics_cmd(),
-            'get-host-metrics --memory'
-        )
+            self.app._get_host_metrics_opts(), set(['--memory']))
         self.mock_global_config(set_rank_method='memory')
         self.assertEqual(
-            self.app._process_get_host_metrics_cmd(),
-            'get-host-metrics --memory'
-        )
+            self.app._get_host_metrics_opts(), set(['--memory']))
         self.mock_global_config(
             set_rank_method='disk-space:%s' % self.app.use_disk_path,
             set_thresholds='load:1 1000')
         self.assertEqual(
-            self.app._process_get_host_metrics_cmd(),
-            'get-host-metrics --disk-space=' + self.app.use_disk_path +
-            ' --load'
+            self.app._get_host_metrics_opts(),
+            set(['--disk-space=' + self.app.use_disk_path, '--load']),
         )
         self.mock_global_config(
             set_rank_method='memory',
@@ -656,8 +642,8 @@ class TestHostAppointer(unittest.TestCase):
         # self.parsed_thresholds etc dict => unordered keys: opts order varies;
         # instead of cataloging all combos or importing itertools, test split.
         self.assertEqual(
-            set(self.app._process_get_host_metrics_cmd().split()),
-            set(['get-host-metrics', '--memory', '--disk-space=/', '--load'])
+            self.app._get_host_metrics_opts(),
+            set(['--disk-space=/', '--load', '--memory']),
         )
 
     def test_remove_bad_hosts(self):
@@ -668,47 +654,24 @@ class TestHostAppointer(unittest.TestCase):
         of HostAppointer.
         """
         self.mock_global_config(set_hosts=['localhost'])
-        self.failUnless(
-            self.app._remove_bad_hosts(
-                self.app.CMD_BASE).get('localhost', False)
-        )
+        self.failUnless(self.app._remove_bad_hosts().get('localhost', False))
         # Test 'localhost' true identifier is treated properly too.
-        self.mock_global_config(set_hosts=[get_fqdn_by_host(None)])
-        self.failUnless(
-            self.app._remove_bad_hosts(
-                self.app.CMD_BASE).get('localhost', False)
-        )
+        self.mock_global_config(set_hosts=[get_host()])
+        self.failUnless(self.app._remove_bad_hosts().get('localhost', False))
 
         self.mock_global_config(set_hosts=['localhost', 'FAKE_HOST'])
         # Check for no exceptions and 'localhost' but not 'FAKE_HOST' data
         # Difficult to unittest for specific stderr string; this is sufficient.
-        self.failUnless(
-            self.app._remove_bad_hosts(
-                self.app.CMD_BASE).get('localhost', False)
-        )
-        self.failUnless(
-            self.app._remove_bad_hosts(
-                self.app.CMD_BASE).get('FAKE_HOST', True)
-        )
-        self.mock_global_config(set_hosts=['localhost'])  # see above RE stderr
-        self.assertEqual(
-            self.app._remove_bad_hosts(self.app.CMD_BASE + ' --nonsense'),
-            {}
-        )
+        self.failUnless(self.app._remove_bad_hosts().get('localhost', False))
+        self.failUnless(self.app._remove_bad_hosts().get('FAKE_HOST', True))
 
         # Apply thresholds impossible to pass; check results in host removal.
         self.mock_global_config(
             set_hosts=['localhost'], set_thresholds='load:15 0.0')
-        self.assertEqual(
-            self.app._remove_bad_hosts(self.app.CMD_BASE + " --load"),
-            {}
-        )
+        self.assertEqual(self.app._remove_bad_hosts(), {})
         self.mock_global_config(
             set_hosts=['localhost'], set_thresholds='memory 1000000000')
-        self.assertEqual(
-            self.app._remove_bad_hosts(self.app.CMD_BASE + " --memory"),
-            {}
-        )
+        self.assertEqual(self.app._remove_bad_hosts(), {})
 
     def test_rank_good_hosts(self):
         """Test the '_rank_good_hosts' method."""
@@ -782,24 +745,24 @@ class TestHostAppointer(unittest.TestCase):
 
             if correct_results[index] == 'HOST_X':  # random, any X={1..5} fine
                 self.assertTrue(
-                    self.app.appoint_host(override_stats=mock_hosts) in
+                    self.app.appoint_host(mock_stats=mock_hosts) in
                     host_list
                 )
             elif correct_results[index] == 'HOST_Y':  # random + thr, X={2,3}
                 self.assertTrue(
-                    self.app.appoint_host(override_stats=mock_hosts) in
+                    self.app.appoint_host(mock_stats=mock_hosts) in
                     host_list[1:3]
                 )
             elif isinstance(correct_results[index], str):
                 self.assertEqual(
-                    self.app.appoint_host(override_stats=mock_hosts),
+                    self.app.appoint_host(mock_stats=mock_hosts),
                     correct_results[index]
                 )
             else:
                 self.assertRaises(
                     correct_results[index],
                     self.app.appoint_host,
-                    override_stats=mock_hosts
+                    mock_stats=mock_hosts
                 )
 
 

--- a/lib/parsec/empysupport.py
+++ b/lib/parsec/empysupport.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2017 NIWA
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/cylc-scan/01-hosts.t
+++ b/tests/cylc-scan/01-hosts.t
@@ -19,9 +19,9 @@
 CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
 HOSTS="$( \
-    cylc get-global-config '--item=[suite host scanning]hosts' 2>'/dev/null')"
+    cylc get-global-config '--item=[suite servers]scan hosts' 2>'/dev/null')"
 if [[ -z "${HOSTS}" || "${HOSTS}" == 'localhost' ]]; then
-    skip_all '"[suite host scanning]hosts" not defined with remote suite hosts'
+    skip_all '"[suite servers]scan hosts" not defined with remote suite hosts'
 fi
 #-------------------------------------------------------------------------------
 set_test_number "$(($(wc -w <<<"${HOSTS}") + 1))"

--- a/tests/job-submission/17-remote-localtime.t
+++ b/tests/job-submission/17-remote-localtime.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/validate/04-builtin-suites.t
+++ b/tests/validate/04-builtin-suites.t
@@ -39,9 +39,17 @@ with open(file_name, 'r') as in_file:
 set_test_number $((( ((${#SUITES[@]})) * 2 )))
 #-------------------------------------------------------------------------------
 # Validate suites.
+NO_EMPY=true
+if cylc check-software 2>'/dev/null' | grep -q '^Python:EmPy.*([^-]*)$'; then
+    NO_EMPY=false
+fi
 for suite in ${SUITES[@]}; do
     suite_name=$(sed 's/\//-/g' <<<"${suite:$ABS_PATH_LENGTH}")
     TEST_NAME="${TEST_NAME_BASE}${suite_name}"
+    if "${NO_EMPY}" && grep -qi '^#!empy' < <(head -1 "${suite}"); then
+        skip 2 "${TEST_NAME}: EmPy not installed"
+        continue
+    fi
     run_ok "${TEST_NAME}" cylc validate "${suite}" -v -v
     filter_warnings "${TEST_NAME}.stderr"
     cmp_ok "${TEST_NAME}.stderr.processed" /dev/null


### PR DESCRIPTION
Fix `localhost` logic:
* Don't bother with host select if no run hosts specified in `global.rc` or if the only choice is `localhost`.
* Use SSH to collect host metrics only for remote hosts. (This was the main problem why I had the unit test failure.)

Improve diagnostics on host metrics command failure. (This was why I was unable to see what went wrong.)

Improve logic for efficiency.
* No need to join then split command option sets.
* No need to use mutliprocess pool - which is quite heavy weight and can cause issues for keyboard interrupt etc. Simply launch SSH commands to all hosts and manage the subprocesses.
* Move `HostAppointer` class to `cylc.scheduler_cli`. This is the only place the class is used. Other remote commands don't need to load this.

Fix other `global.rc` logic.
* Scan hosts logic.
* Port range dump and load logic.

(This branch should be easier to review by looking at the 2 commits separately.)