### PR TITLE
host-sel add simple test

### DIFF
--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -550,6 +550,19 @@ class TestHostAppointer(unittest.TestCase):
             'HOST_1'
         )
 
+    def test_simple(self):
+        """Simple end-to-end test of the host appointer."""
+        self.mock_global_config()
+        self.assertEqual(
+            self.app.appoint_host(),
+            'localhost'
+        )
+        self.mock_global_config(set_hosts=['foo'])
+        self.assertEqual(
+            self.app.appoint_host(),
+            'foo'
+        )
+
     def test_parse_thresholds(self):
         """Test the 'parse_thresholds' method."""
         self.mock_global_config()


### PR DESCRIPTION
Really simple functionality test to make sure global config defaults work the way they are supposed to.